### PR TITLE
create sparate export for vercel kv apl

### DIFF
--- a/.changeset/mean-ligers-care.md
+++ b/.changeset/mean-ligers-care.md
@@ -1,0 +1,5 @@
+---
+"@saleor/app-sdk": patch
+---
+
+Changed export path of VercelKv APL. Now its not exported from shared index file.

--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
       "import": "./APL/index.mjs",
       "require": "./APL/index.js"
     },
+    "./APL/vercel-kv": {
+      "types": "./APL/vercel-kv/index.d.ts",
+      "import": "./APL/vercel-kv/index.mjs",
+      "require": "./APL/vercel-kv/index.js"
+    },
     "./settings-manager": {
       "types": "./settings-manager/index.d.ts",
       "import": "./settings-manager/index.mjs",

--- a/src/APL/index.ts
+++ b/src/APL/index.ts
@@ -3,5 +3,3 @@ export * from "./env-apl";
 export * from "./file-apl";
 export * from "./saleor-cloud";
 export * from "./upstash-apl";
-// eslint-disable-next-line camelcase
-export { VercelKvApl as _experimental_VercelKvApl } from "./vercel-kv";

--- a/src/APL/vercel-kv/index.ts
+++ b/src/APL/vercel-kv/index.ts
@@ -1,1 +1,2 @@
-export * from "./vercel-kv-apl";
+// eslint-disable-next-line camelcase
+export { VercelKvApl as _experimental_VercelKvApl } from "./vercel-kv-apl";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     "src/verify-jwt.ts",
     "src/verify-signature.ts",
     "src/APL/index.ts",
+    "src/APL/vercel-kv/index.ts",
     "src/app-bridge/index.ts",
     "src/app-bridge/next/index.ts",
     "src/handlers/next/index.ts",


### PR DESCRIPTION
having index.ts that exports all APLs means that all files are evaluated, no matter which apl is included.

it causes app to break because of missing dependency of vercel kv, even is its not used