### PR TITLE
Parse schema version when processing saleor webhook

### DIFF
--- a/.changeset/fair-ads-trade.md
+++ b/.changeset/fair-ads-trade.md
@@ -1,0 +1,5 @@
+---
+"@saleor/app-sdk": minor
+---
+
+Parse schema version from request

--- a/.changeset/fair-ads-trade.md
+++ b/.changeset/fair-ads-trade.md
@@ -2,4 +2,6 @@
 "@saleor/app-sdk": minor
 ---
 
-Parse schema version from request
+Fix wrong logic introduced in [0.49.0](https://github.com/saleor/app-sdk/releases/tag/v0.49.0): there is not header `saleor-schema-version` when app-sdk is processing saleor webhook. This header is only present on install request.
+
+Now app-sdk will try to parse version from `version` field on GraphQL subscription [Event](https://docs.saleor.io/docs/3.x/api-storefront/miscellaneous/interfaces/event#code-style-fontweight-normal-eventbversionbcodestring-). If field is not present `null` will be returned.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saleor/app-sdk",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "SDK for building great Saleor Apps",
   "scripts": {
     "prepublishOnly": "pnpm build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saleor/app-sdk",
-  "version": "0.49.1",
+  "version": "0.49.0",
   "description": "SDK for building great Saleor Apps",
   "scripts": {
     "prepublishOnly": "pnpm build",

--- a/src/handlers/next/saleor-webhooks/process-saleor-webhook.test.ts
+++ b/src/handlers/next/saleor-webhooks/process-saleor-webhook.test.ts
@@ -172,26 +172,4 @@ describe("processAsyncSaleorWebhook", () => {
       schemaVersion: null,
     });
   });
-
-  it("Return schema version if saleor-schema-version header is present", async () => {
-    await expect(
-      processSaleorWebhook({
-        req: mockRequest,
-        apl: mockAPL,
-        allowedEvent: "PRODUCT_UPDATED",
-      })
-    ).resolves.toStrictEqual({
-      authData: {
-        appId: "mock-app-id",
-        domain: "example.com",
-        jwks: "{}",
-        saleorApiUrl: "https://example.com/graphql/",
-        token: "mock-token",
-      },
-      baseUrl: "https://some-saleor-host.cloud",
-      event: "product_updated",
-      payload: {},
-      schemaVersion: null,
-    });
-  });
 });

--- a/src/handlers/next/saleor-webhooks/process-saleor-webhook.test.ts
+++ b/src/handlers/next/saleor-webhooks/process-saleor-webhook.test.ts
@@ -45,7 +45,6 @@ describe("processAsyncSaleorWebhook", () => {
         "saleor-event": "product_updated",
         "saleor-signature": "mocked_signature",
         "content-length": "0", // is ignored by mocked raw-body.
-        "saleor-schema-version": "3.19",
       },
       method: "POST",
       // body can be skipped because we mock it with raw-body
@@ -192,7 +191,7 @@ describe("processAsyncSaleorWebhook", () => {
       baseUrl: "https://some-saleor-host.cloud",
       event: "product_updated",
       payload: {},
-      schemaVersion: 3.19,
+      schemaVersion: null,
     });
   });
 });

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,2 +1,3 @@
 export * from "./is-in-iframe";
+export * from "./schema-version";
 export * from "./use-is-mounted";

--- a/src/util/schema-version.test.ts
+++ b/src/util/schema-version.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSchemaVersion } from "./schema-version";
+
+describe("parseSchemaVersion", () => {
+  it("Parses version string", () => {
+    expect(parseSchemaVersion("3.19.1")).toBe(3.19);
+  });
+});

--- a/src/util/schema-version.test.ts
+++ b/src/util/schema-version.test.ts
@@ -1,9 +1,45 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { parseSchemaVersion } from "./schema-version";
 
 describe("parseSchemaVersion", () => {
-  it("Parses version string", () => {
-    expect(parseSchemaVersion("3.19.1")).toBe(3.19);
-  });
+  test.each([
+    {
+      rawVersion: "3",
+      parsedVersion: null,
+    },
+    {
+      rawVersion: "3.19",
+      parsedVersion: 3.19,
+    },
+    {
+      rawVersion: "3.19.1",
+      parsedVersion: 3.19,
+    },
+    {
+      rawVersion: "malformed",
+      parsedVersion: null,
+    },
+    {
+      rawVersion: "malformed.raw",
+      parsedVersion: null,
+    },
+    {
+      rawVersion: "malformed.raw.version",
+      parsedVersion: null,
+    },
+    {
+      rawVersion: null,
+      parsedVersion: null,
+    },
+    {
+      rawVersion: undefined,
+      parsedVersion: null,
+    },
+  ])(
+    "Parses version string from: $rawVersion to: $parsedVersion",
+    ({ rawVersion, parsedVersion }) => {
+      expect(parseSchemaVersion(rawVersion)).toBe(parsedVersion);
+    }
+  );
 });

--- a/src/util/schema-version.ts
+++ b/src/util/schema-version.ts
@@ -1,0 +1,12 @@
+export const parseSchemaVersion = (versionField: string | undefined | null): number | null => {
+  if (!versionField) {
+    return null;
+  }
+
+  const [major, minor] = versionField.split(".");
+  if (major && minor) {
+    return parseFloat(`${major}.${minor}`);
+  }
+
+  return null;
+};

--- a/src/util/schema-version.ts
+++ b/src/util/schema-version.ts
@@ -1,9 +1,12 @@
-export const parseSchemaVersion = (versionField: string | undefined | null): number | null => {
-  if (!versionField) {
+export const parseSchemaVersion = (rawVersion: string | undefined | null): number | null => {
+  if (!rawVersion) {
     return null;
   }
 
-  const [major, minor] = versionField.split(".");
+  const [majorString, minorString] = rawVersion.split(".");
+  const major = parseInt(majorString, 10);
+  const minor = parseInt(minorString, 10);
+
   if (major && minor) {
     return parseFloat(`${major}.${minor}`);
   }


### PR DESCRIPTION
Fix wrong logic introduced in [0.49.0](https://github.com/saleor/app-sdk/releases/tag/v0.49.0): there is not header `saleor-schema-version` when app-sdk is processing saleor webhook. This header is only present on install request.

Now app-sdk will try to parse version from `version` field on GraphQL subscription [Event](https://docs.saleor.io/docs/3.x/api-storefront/miscellaneous/interfaces/event#code-style-fontweight-normal-eventbversionbcodestring-). If field is not present `null` will be returned.