### PR TITLE
Deprecate `buildSyncWebhookResponsePayload`

### DIFF
--- a/.changeset/eight-files-relate.md
+++ b/.changeset/eight-files-relate.md
@@ -1,0 +1,5 @@
+---
+"@saleor/app-sdk": patch
+---
+
+Deprecate `buildSyncWebhookResponsePayload` function. Saleor now exposes JSON schema for webhook response payloads that can be used to generate TypeScript types. See [Saleor docs](https://docs.saleor.io/developer/extending/apps/developing-apps/generating-types-for-sync-webhooks) for more info.

--- a/src/handlers/shared/sync-webhook-response-builder.ts
+++ b/src/handlers/shared/sync-webhook-response-builder.ts
@@ -258,6 +258,8 @@ export type SyncWebhookResponsesMap<V extends SaleorVersion = "3.20"> = CoreSync
 } & TransactionWebhookResponses<V>;
 
 /**
+ * @deprecated Saleor now exposes JSON schema for webhook response payloads that can be used to generate TypeScript types. See https://docs.saleor.io/developer/extending/apps/developing-apps/generating-types-for-sync-webhooks for more details.
+ *
  * Identity function, but it works on Typescript level to pick right payload based on first param
  */
 export const buildSyncWebhookResponsePayload = <


### PR DESCRIPTION
Deprecate `buildSyncWebhookResponsePayload` function. Saleor now exposes JSON schema for webhook response payloads that can be used to generate TypeScript types. See [Saleor docs](https://docs.saleor.io/developer/extending/apps/developing-apps/generating-types-for-sync-webhooks) for more info.